### PR TITLE
Multiple expand/shorten arguments

### DIFF
--- a/Provider/ProviderProxy.php
+++ b/Provider/ProviderProxy.php
@@ -69,9 +69,12 @@ class ProviderProxy implements UrlShortenerProviderInterface
      */
     public function shorten(LinkInterface $link)
     {
+        $args = func_get_args();
+        $func = [$this->provider, 'shorten'];
+
         $event = $this->startProfiling($link->getLongUrl());
 
-        $this->provider->shorten($link);
+        call_user_func_array($func, $args);
 
         $this->stopProfiling($event, $link->getShortUrl());
     }
@@ -81,9 +84,12 @@ class ProviderProxy implements UrlShortenerProviderInterface
      */
     public function expand(LinkInterface $link)
     {
+        $args = func_get_args();
+        $func = [$this->provider, 'expand'];
+
         $event = $this->startProfiling($link->getShortUrl());
 
-        $this->provider->expand($link);
+        call_user_func_array($func, $args);
 
         $this->stopProfiling($event, $link->getLongUrl());
     }

--- a/Provider/ProviderProxy.php
+++ b/Provider/ProviderProxy.php
@@ -69,11 +69,9 @@ class ProviderProxy implements UrlShortenerProviderInterface
      */
     public function shorten(LinkInterface $link)
     {
-        $func = array($this->provider, 'shorten');
-
         $event = $this->startProfiling($link->getLongUrl());
 
-        call_user_func_array($func, func_get_args());
+        call_user_func_array(array($this->provider, 'shorten'), func_get_args());
 
         $this->stopProfiling($event, $link->getShortUrl());
     }
@@ -83,11 +81,9 @@ class ProviderProxy implements UrlShortenerProviderInterface
      */
     public function expand(LinkInterface $link)
     {
-        $func = array($this->provider, 'expand');
-
         $event = $this->startProfiling($link->getShortUrl());
 
-        call_user_func_array($func, func_get_args());
+        call_user_func_array(array($this->provider, 'expand'), func_get_args());
 
         $this->stopProfiling($event, $link->getLongUrl());
     }

--- a/Provider/ProviderProxy.php
+++ b/Provider/ProviderProxy.php
@@ -69,12 +69,11 @@ class ProviderProxy implements UrlShortenerProviderInterface
      */
     public function shorten(LinkInterface $link)
     {
-        $args = func_get_args();
-        $func = [$this->provider, 'shorten'];
+        $func = array($this->provider, 'shorten');
 
         $event = $this->startProfiling($link->getLongUrl());
 
-        call_user_func_array($func, $args);
+        call_user_func_array($func, func_get_args());
 
         $this->stopProfiling($event, $link->getShortUrl());
     }
@@ -84,12 +83,11 @@ class ProviderProxy implements UrlShortenerProviderInterface
      */
     public function expand(LinkInterface $link)
     {
-        $args = func_get_args();
-        $func = [$this->provider, 'expand'];
+        $func = array($this->provider, 'expand');
 
         $event = $this->startProfiling($link->getShortUrl());
 
-        call_user_func_array($func, $args);
+        call_user_func_array($func, func_get_args());
 
         $this->stopProfiling($event, $link->getLongUrl());
     }

--- a/Tests/Provider/ProviderProxyTest.php
+++ b/Tests/Provider/ProviderProxyTest.php
@@ -61,6 +61,38 @@ class ProviderProxyTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test that the proxy will pass through additional
+     * arguments to `shorten()`
+     */
+    public function testVariadicShorten()
+    {
+        $link = $this->getMock('Mremi\UrlShortener\Model\LinkInterface');
+
+        $this->provider
+            ->expects($this->once())
+            ->method('shorten')
+            ->with($this->equalTo($link), $this->equalTo('bar'), $this->equalTo(12));
+
+        $this->providerProxy->shorten($link, 'bar', 12);
+    }
+
+    /**
+     * Test that the proxy will pass through additional
+     * arguments to `expand()`
+     */
+    public function testVariadicExpand()
+    {
+        $link = $this->getMock('Mremi\UrlShortener\Model\LinkInterface');
+
+        $this->provider
+            ->expects($this->once())
+            ->method('expand')
+            ->with($this->equalTo($link), $this->equalTo('foo'));
+
+        $this->providerProxy->expand($link, 'foo');
+    }
+
+    /**
      * Initializes providerProxy & provider properties
      */
     protected function setUp()


### PR DESCRIPTION
Hi @mremi 

Thanks for your bundle.

This allows for multiple arguments to be supplied to the `shorten()` and `expand()` methods. The only downside I see is that `call_user_func_array()` is slightly slower.

For example, the bitly provider has an additional `$domain` argument on the `shorten()` method:
https://github.com/mremi/UrlShortener/blob/master/src/Mremi/UrlShortener/Provider/Bitly/BitlyProvider.php#L64

I really only need it on the `shorten()` method, so I can resubmit with just that change.
(Oh, the `$args = func_get_args();` assignment is a bit redundant, I could remove that too..)

What do you think?