### PR TITLE
Add compatibility with Symfony 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ MremiUrlShortenerBundle
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/mremi/UrlShortenerBundle/badges/quality-score.png?s=a9e232e7ec75d70c038950b2f1aa72b313a31271)](https://scrutinizer-ci.com/g/mremi/UrlShortenerBundle/)
 [![Code Coverage](https://scrutinizer-ci.com/g/mremi/UrlShortenerBundle/badges/coverage.png?s=ddfb206093586a764b3fc9459a0cde20c108e547)](https://scrutinizer-ci.com/g/mremi/UrlShortenerBundle/)
 
-This bundle implements the [UrlShortener](https://github.com/mremi/UrlShortener) library for Symfony2.
+This bundle implements the [UrlShortener](https://github.com/mremi/UrlShortener) library for Symfony2+.
 
 ## License
 
@@ -17,7 +17,10 @@ This bundle is available under the [MIT license](Resources/meta/LICENSE).
 
 ## Prerequisites
 
-This version of the bundle requires Symfony 2.1+.
+This version of the bundle requires Symfony 2.8+.
+
+For compatibility with Symfony 2.7 or earlier, please use ~1.0 version of this
+bundle.
 
 **Basic Docs**
 
@@ -50,6 +53,17 @@ Add MremiUrlShortenerBundle in your composer.json:
 {
     "require": {
         "mremi/url-shortener-bundle": "dev-master"
+    }
+}
+```
+
+If you are using Symfony 2.7 or earlier, please specify ~1.0 version in your
+composer.json:
+
+```js
+{
+    "require": {
+        "mremi/url-shortener-bundle": "~1.0"
     }
 }
 ```

--- a/Resources/config/manager.xml
+++ b/Resources/config/manager.xml
@@ -10,7 +10,8 @@
             <argument />
         </service>
 
-        <service id="mremi_url_shortener.entity_manager" factory-service="doctrine" factory-method="getManager" class="Doctrine\ORM\EntityManager" public="false">
+        <service id="mremi_url_shortener.entity_manager" class="Doctrine\ORM\EntityManager" public="false">
+            <factory class="doctrine" method="getManager" />
         </service>
 
         <service id="mremi_url_shortener.link_manager.doctrine" class="Mremi\UrlShortenerBundle\Doctrine\LinkManager" public="false">

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "mremi/url-shortener-bundle",
     "type": "symfony-bundle",
-    "description": "Implementation of UrlShortener library for Symfony2",
-    "keywords": ["Symfony2", "url", "shortener", "api"],
+    "description": "Implementation of UrlShortener library for Symfony2/Symfony3",
+    "keywords": ["Symfony2", "Symfony3", "url", "shortener", "api"],
     "homepage": "https://github.com/mremi/UrlShortenerBundle",
     "license": "MIT",
     "authors": [
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/framework-bundle": "~2.1",
+        "symfony/framework-bundle": "~2.8 | ~3.0",
         "mremi/url-shortener": "~1.0"
     },
     "autoload": {


### PR DESCRIPTION
This PR adds Symfony 3 compatibility to this handy bundle.

Unit tests pass using both ~2.6 (v2.8.6) and ~3.0 (v3.0.6) symfony branches.

Could you also please tag the new version as v1.1.0 or v2.0.0 and make it available on the Packagist?