### PR TITLE
Requirement of url-shortener set to ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
-        "symfony/framework-bundle": "~2.8 | ~3.0",
-        "mremi/url-shortener": "~1.0"
+        "php": ">=5.3.9",
+        "symfony/framework-bundle": "^2.8 || ^3.0",
+        "mremi/url-shortener": "^2.0"
     },
     "autoload": {
         "psr-0": { "Mremi\\UrlShortenerBundle": "" }


### PR DESCRIPTION
- Updated `"php"`-requirement as `symfony/framework-bundle` it requires `"php": ">=5.3.9"`