### PR TITLE
Requirement of url-shortener set to ^2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: php
 
+dist: trusty
+
 php:
-  - 5.3
-  - 5.4
-  - 5.5
   - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
   - hhvm
 
 before_script: composer install --dev --prefer-source

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,12 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
-        "symfony/framework-bundle": "~2.8 | ~3.0",
-        "mremi/url-shortener": "~1.0"
+        "php": "^5.5 || ^7.0",
+        "symfony/framework-bundle": "^2.8 || ^3.0",
+        "mremi/url-shortener": "^2.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^5.7"
     },
     "autoload": {
         "psr-0": { "Mremi\\UrlShortenerBundle": "" }


### PR DESCRIPTION
Updated `php` requirement to match the requirement of `url-shortener` library.
Updated `.travis.yml` and set the distribution to Trusty because Travis CI displayed this error: HHVM is no longer supported on Ubuntu Precise. Please consider using Trusty with `dist: trusty`.